### PR TITLE
This code change ensures numpy is explicitly included setup.up.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 from distutils.core import setup
 from distutils.extension import Extension
 from Cython.Build import cythonize
+import numpy
 
 ext_modules = [
     Extension("pymultimedia",
@@ -8,4 +9,5 @@ ext_modules = [
 ]
 
 setup(name="PyMultimedia",
+      include_dirs=[numpy.get_include()],
       ext_modules=cythonize(ext_modules))

--- a/setup.py
+++ b/setup.py
@@ -10,4 +10,4 @@ ext_modules = [
 
 setup(name="PyMultimedia",
       include_dirs=[numpy.get_include()],
-      ext_modules=cythonize(ext_modules))
+      ext_modules=cythonize(ext_modules, compiler_directives={'language_level':3}))

--- a/src/multimedia.c
+++ b/src/multimedia.c
@@ -144,6 +144,6 @@ int main(int argc, char **argv)
     stop_capturing(device_handle, buffs);
     uninit_device(buffs);
     close_device(device_handle);
-    fprintf(stderr, "\\n");
+    fprintf(stderr, "\n");
     return 0;
 }

--- a/src/multimedia.c
+++ b/src/multimedia.c
@@ -23,18 +23,18 @@
 void usage(FILE *fp, int argc, char **argv, char* dev_name, int frame_count)
 {
         fprintf(fp,
-                 "Usage: %s [options]\\n\\n"
-                 "Version 1.3\\n"
-                 "Options:\\n"
-                 "-d | --device name   Video device name [%s]n"
-                 "-h | --help          Print this messagen"
-                 "-m | --mmap          Use memory mapped buffers [default]n"
-                 "-r | --read          Use read() callsn"
-                 "-u | --userp         Use application allocated buffersn"
-                 "-o | --output        Outputs stream to stdoutn"
-                 "-f | --format        Force format to 640x480 YUYVn"
-                 "-c | --count         Number of frames to grab [%i]n"
-                 "-w | --window        Crop window"
+                 "Usage: %s [options]\n"
+                 "Version 1.3\n"
+                 "Options:\n"
+                 "-d  | --device name   Video device name [%s]n\n"
+                 "-h  | --help          Print this messagen\n"
+                 "-m  | --mmap          Use memory mapped buffers [default]n\n"
+                 "-r  | --read          Use read() callsn\n"
+                 "-u  | --userp         Use application allocated buffersn\n"
+                 "-o  | --output        Outputs stream to stdoutn\n"
+                 "-f  | --format        Force format to 640x480 YUYVn\n"
+                 "-c  | --count         Number of frames to grab [%i]n\n"
+                 "-w  | --window        Crop window\n"
                  "",
                  argv[0], dev_name, frame_count);
 }


### PR DESCRIPTION
I ran into this issue while trying to build the on Ubuntu 18:04:
```
(v3) </github/xavier/multimedia/ [update-readme @ 9bca1ef94eb6ddabde2c18ddcc0753de8ea49a18]>
[11:15 PM]->make
gcc -g3 -Isrc src/multimedia.c src/camera.c src/imageprocessing.c -o build/multimedia -lm
python3 setup.py build_ext --inplace && rm -f src/pymultimedia.c
running build_ext
building 'pymultimedia' extension
creating build/temp.linux-x86_64-3.6
creating build/temp.linux-x86_64-3.6/src
x86_64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -Isrc -I/home/dpflan/Projects/github/xavier/multimedia/v3/include -I/usr/include/python3.6m -c src/pymultimedia.c -o build/temp.linux-x86_64-3.6/src/pymultimedia.o
src/pymultimedia.c:632:10: fatal error: numpy/arrayobject.h: No such file or directory
 #include "numpy/arrayobject.h"
          ^~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```

After searching for the problem, a resolution was found that included importing numpy and then using it in the value for `setup`s keyword argument `include_dirs as part of an array.

By adding using `numpy.get_include()`, this allowed compilation but with the following warning:
```
(v3) </github/xavier/multimedia/ [update-setup @ 74e5d32a8eeed426fd53f003daeb7680df5caa45]>
[11:21 PM]->make
gcc -g3 -Isrc src/multimedia.c src/camera.c src/imageprocessing.c -o build/multimedia -lm
python3 setup.py build_ext --inplace && rm -f src/pymultimedia.c
Compiling src/pymultimedia.pyx because it changed.
[1/1] Cythonizing src/pymultimedia.pyx
running build_ext
building 'pymultimedia' extension
creating build/temp.linux-x86_64-3.6
creating build/temp.linux-x86_64-3.6/src
x86_64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -Isrc -I/home/dpflan/Projects/github/xavier/multimedia/v3/lib/python3.6/site-packages/numpy/core/include -I/home/dpflan/Projects/github/xavier/multimedia/v3/include -I/usr/include/python3.6m -c src/pymultimedia.c -o build/temp.linux-x86_64-3.6/src/pymultimedia.o
In file included from /home/dpflan/Projects/github/xavier/multimedia/v3/lib/python3.6/site-packages/numpy/core/include/numpy/ndarraytypes.h:1821:0,
                 from /home/dpflan/Projects/github/xavier/multimedia/v3/lib/python3.6/site-packages/numpy/core/include/numpy/ndarrayobject.h:18,
                 from /home/dpflan/Projects/github/xavier/multimedia/v3/lib/python3.6/site-packages/numpy/core/include/numpy/arrayobject.h:4,
                 from src/pymultimedia.c:632:
/home/dpflan/Projects/github/xavier/multimedia/v3/lib/python3.6/site-packages/numpy/core/include/numpy/npy_1_7_deprecated_api.h:15:2: warning: #warning "Using deprecated NumPy API, disable it by " "#defining NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION" [-Wcpp]
 #warning "Using deprecated NumPy API, disable it by " \
  ^~~~~~~
```

@ilmarinen:
1. Can you try building the artifact with this branch on your machine?
2. When you build do you encounter any compilation warnirngs?

------------------------------------------------------------------------------------------------------
I also add minor style changes for the flag/opts information in `src/multimedia.c`.
Previously out to my terminal did not have new lines as desired:
```(v3) </github/xavier/multimedia/ [update-setup @ 74e5d32a8eeed426fd53f003daeb7680df5caa45]>
[12:30 AM]->./build/multimedia -h
Usage: ./build/multimedia [options]\n\nVersion 1.3\nOptions:\n-d | --device name   Video device name [/dev/video0]n-h | --help          Print this messagen-m | --mmap          Use memory mapped buffers [default]n-r | --read          Use read() callsn-u | --userp         Use application allocated buffersn-o | --output        Outputs stream to stdoutn-f | --format        Force format to 640x480 YUYVn-c | --count         Number of frames to grab [70]n-w | --window        Crop window(v3) </github/xavier/multimedia/ [update-setup @ 74e5d32a8eeed426fd53f003daeb7680df5caa45]>
[12:30 AM]->
```
Now the format is:
```/github/xavier/multimedia/ [update-setup @ 74e5d32a8eeed426fd53f003daeb7680df5caa45]>
[12:29 AM]->./build/multimedia -h
Usage: ./build/multimedia [options]
Version 1.3
Options:
-d  | --device name   Video device name [/dev/video0]n
-h  | --help          Print this messagen
-m  | --mmap          Use memory mapped buffers [default]n
-r  | --read          Use read() callsn
-u  | --userp         Use application allocated buffersn
-o  | --output        Outputs stream to stdoutn
-f  | --format        Force format to 640x480 YUYVn
-c  | --count         Number of frames to grab [70]n
-w  | --window        Crop window
```

@ilmarinen 
1. Were you seeing the same output without newlines with this code change?

I am using Ubuntu 18.04.