### PR TITLE
Add a bsic Canny Edge Detector

### DIFF
--- a/src/camera.c
+++ b/src/camera.c
@@ -43,15 +43,16 @@ void process_image(const void *p, int size, unsigned int width, unsigned int hei
     char output_filename[50], output_cropped_filename[50],
          output_grayscale_filename[50], output_grayscale_padded_filename[50],
          output_blurred_uniform_filename[50], output_blurred_gaussian_filename[50],
-         output_blurred_gaussian2d_filename[50];
+         output_blurred_gaussian2d_filename[50], output_canny_edge_detector_filename[50];
     unsigned char *pRGB24, *pCroppedRGB24, *pGrayscale, *pGrayscalePadded, *pGrayscaleBlurred, *pGrayscaleBlurredGaussian,
-        *pGrayscaleBlurredGaussian2d;
+        *pGrayscaleBlurredGaussian2d, *pCannyEdges;
     pRGB24 = (unsigned char*)malloc(ALIGN_TO_FOUR(3*width)*height);
     pGrayscale = (unsigned char*)malloc(ALIGN_TO_FOUR(width)*height);
     pGrayscalePadded = (unsigned char*)malloc(ALIGN_TO_FOUR(ALIGN_TO_FOUR(width + 2*1)*(height + 2*1)));
     pGrayscaleBlurred = (unsigned char*)malloc(ALIGN_TO_FOUR(width)*height);
     pGrayscaleBlurredGaussian = (unsigned char*)malloc(ALIGN_TO_FOUR(width)*height);
     pGrayscaleBlurredGaussian2d = (unsigned char*)malloc(ALIGN_TO_FOUR(width)*height);
+    pCannyEdges = (unsigned char*)malloc(ALIGN_TO_FOUR(width)*height);
     pCroppedRGB24 = (unsigned char*)malloc(ALIGN_TO_FOUR(3*(c_window.end_x - c_window.start_x))*(c_window.end_y - c_window.start_y));
 
     sprintf(output_filename, "%s-%d.bmp", output_filestring, frame_number);
@@ -61,6 +62,7 @@ void process_image(const void *p, int size, unsigned int width, unsigned int hei
     sprintf(output_blurred_uniform_filename, "%s-%d-gray-blurred-uniform.bmp", output_filestring, frame_number);
     sprintf(output_blurred_gaussian_filename, "%s-%d-gray-blurred-gaussian.bmp", output_filestring, frame_number);
     sprintf(output_blurred_gaussian2d_filename, "%s-%d-gray-blurred-gaussian-2d.bmp", output_filestring, frame_number);
+    sprintf(output_canny_edge_detector_filename, "%s-%d-canny-edges.bmp", output_filestring, frame_number);
 
     YUYV2RGB24((unsigned char *)p, width, height, pRGB24);
     RGB24toGrayscale(pRGB24, width, height, pGrayscale);
@@ -68,12 +70,14 @@ void process_image(const void *p, int size, unsigned int width, unsigned int hei
     UniformBlur(pGrayscale, width, height, pGrayscaleBlurred);
     GaussianBlur2DKernel(pGrayscale, width, height, pGrayscaleBlurredGaussian2d, 1.0);
     GaussianBlur(pGrayscale, width, height, pGrayscaleBlurredGaussian, 1.0);
+    CannyEdgeDetector(pGrayscale, width, height, pCannyEdges, 2.0, 5.0, 10.0);
 
     GrayScaleWriter(pGrayscale, width, height, output_grayscale_filename);
     GrayScaleWriter(pGrayscalePadded, (width + 2), (height + 2), output_grayscale_padded_filename);
     GrayScaleWriter(pGrayscaleBlurred, width, height, output_blurred_uniform_filename);
     GrayScaleWriter(pGrayscaleBlurredGaussian, width, height, output_blurred_gaussian_filename);
     GrayScaleWriter(pGrayscaleBlurredGaussian2d, width, height, output_blurred_gaussian2d_filename);
+    GrayScaleWriter(pCannyEdges, width, height, output_canny_edge_detector_filename);
     cropRGB24(pRGB24, width, height, c_window.start_x, c_window.start_y, c_window.end_x, c_window.end_y, pCroppedRGB24);
     BMPwriter(pCroppedRGB24, 24, (c_window.end_x - c_window.start_x), (c_window.end_y - c_window.start_y), output_cropped_filename);
     BMPwriter(pRGB24, 24, width, height, output_filename);
@@ -84,6 +88,7 @@ void process_image(const void *p, int size, unsigned int width, unsigned int hei
     free(pGrayscaleBlurred);
     free(pGrayscaleBlurredGaussian);
     free(pGrayscaleBlurredGaussian2d);
+    free(pCannyEdges);
 
     fflush(stderr);
     fprintf(stderr, ".");

--- a/src/imageprocessing.c
+++ b/src/imageprocessing.c
@@ -607,6 +607,36 @@ void getGaussianKernel1D(double* kernel, double sigma, int kernelSize)
     }
 }
 
+void getDGausianKernel1D(double* kernel, double sigma, int kernelSize)
+{
+    int i, max;
+    double value, sum;
+
+    max = (kernelSize - 1) / 2.0;
+    sum = 0.0;
+
+    for(i=0; i <= 2 * max; i++) {
+        value = (-(i - max)/(sigma * sigma)) * exp(-(i - max)*(i - max)/(2 * sigma * sigma))/(sigma *sqrt(2 * M_PI));
+        kernel[i] = value;
+        sum = sum + kernel[i];
+    }
+}
+
+void getD2GausianKernel1D(double* kernel, double sigma, int kernelSize)
+{
+    int i, max;
+    double value, sum;
+
+    max = (kernelSize - 1) / 2.0;
+    sum = 0.0;
+
+    for(i=0; i <= 2 * max; i++) {
+        value = (-1.0/(sigma * sigma) + ((i - max) * (i - max)/(sigma * sigma * sigma * sigma))) * exp(-(i - max)*(i - max)/(2 * sigma * sigma))/(sigma *sqrt(2 * M_PI));
+        kernel[i] = value;
+        sum = sum + kernel[i];
+    }
+}
+
 void getGaussianKernel2D(double* kernel, double sigma, int kernelSize)
 {
     int i, j, max;
@@ -632,6 +662,116 @@ void getGaussianKernel2D(double* kernel, double sigma, int kernelSize)
     }
 }
 
+int GaussianDerivativeX(unsigned char* input_grayscale, int width, int height, unsigned char* output_grayscale, double sigma)
+{
+    double* kernel_x;
+    double* kernel_y;
+    int kernel_size;
+    unsigned char* temp_grayscale_v;
+
+    kernel_size = 2 * ((int) (3*sigma)) + 1;
+
+    temp_grayscale_v = (unsigned char*)malloc(ALIGN_TO_FOUR(width) * height);
+    kernel_x = (double *)malloc(kernel_size * kernel_size * sizeof(double));
+    kernel_y = (double *)malloc(kernel_size * kernel_size * sizeof(double));
+
+    getDGausianKernel1D(kernel_x, sigma, kernel_size);
+    getGaussianKernel1D(kernel_y, sigma, kernel_size);
+
+    convolve2Dwith1Dkernel(kernel_y, kernel_size, input_grayscale, width, height, temp_grayscale_v, VERTICAL);
+    convolve2Dwith1Dkernel(kernel_x, kernel_size, temp_grayscale_v, width, height, output_grayscale, HORIZONTAL);
+
+    return 0;
+}
+
+int GaussianDerivativeY(unsigned char* input_grayscale, int width, int height, unsigned char* output_grayscale, double sigma)
+{
+    double* kernel_x;
+    double* kernel_y;
+    int kernel_size;
+    unsigned char* temp_grayscale_v;
+
+    kernel_size = 2 * ((int) (3*sigma)) + 1;
+
+    temp_grayscale_v = (unsigned char*)malloc(ALIGN_TO_FOUR(width) * height);
+    kernel_x = (double *)malloc(kernel_size * kernel_size * sizeof(double));
+    kernel_y = (double *)malloc(kernel_size * kernel_size * sizeof(double));
+
+    getDGausianKernel1D(kernel_y, sigma, kernel_size);
+    getGaussianKernel1D(kernel_x, sigma, kernel_size);
+
+    convolve2Dwith1Dkernel(kernel_y, kernel_size, input_grayscale, width, height, temp_grayscale_v, VERTICAL);
+    convolve2Dwith1Dkernel(kernel_x, kernel_size, temp_grayscale_v, width, height, output_grayscale, HORIZONTAL);
+
+    return 0;
+}
+
+int GaussianDerivativeXX(unsigned char* input_grayscale, int width, int height, unsigned char* output_grayscale, double sigma)
+{
+    double* kernel_x;
+    double* kernel_y;
+    int kernel_size;
+    unsigned char* temp_grayscale_v;
+
+    kernel_size = 2 * ((int) (3*sigma)) + 1;
+
+    temp_grayscale_v = (unsigned char*)malloc(ALIGN_TO_FOUR(width) * height);
+    kernel_x = (double *)malloc(kernel_size * kernel_size * sizeof(double));
+    kernel_y = (double *)malloc(kernel_size * kernel_size * sizeof(double));
+
+    getD2GausianKernel1D(kernel_x, sigma, kernel_size);
+    getGaussianKernel1D(kernel_y, sigma, kernel_size);
+
+    convolve2Dwith1Dkernel(kernel_y, kernel_size, input_grayscale, width, height, temp_grayscale_v, VERTICAL);
+    convolve2Dwith1Dkernel(kernel_x, kernel_size, temp_grayscale_v, width, height, output_grayscale, HORIZONTAL);
+
+    return 0;
+}
+
+int GaussianDerivativeYY(unsigned char* input_grayscale, int width, int height, unsigned char* output_grayscale, double sigma)
+{
+    double* kernel_x;
+    double* kernel_y;
+    int kernel_size;
+    unsigned char* temp_grayscale_v;
+
+    kernel_size = 2 * ((int) (3*sigma)) + 1;
+
+    temp_grayscale_v = (unsigned char*)malloc(ALIGN_TO_FOUR(width) * height);
+    kernel_x = (double *)malloc(kernel_size * kernel_size * sizeof(double));
+    kernel_y = (double *)malloc(kernel_size * kernel_size * sizeof(double));
+
+    getD2GausianKernel1D(kernel_y, sigma, kernel_size);
+    getGaussianKernel1D(kernel_x, sigma, kernel_size);
+
+    convolve2Dwith1Dkernel(kernel_y, kernel_size, input_grayscale, width, height, temp_grayscale_v, VERTICAL);
+    convolve2Dwith1Dkernel(kernel_x, kernel_size, temp_grayscale_v, width, height, output_grayscale, HORIZONTAL);
+
+    return 0;
+}
+
+int GaussianDerivativeXY(unsigned char* input_grayscale, int width, int height, unsigned char* output_grayscale, double sigma)
+{
+    double* kernel_x;
+    double* kernel_y;
+    int kernel_size;
+    unsigned char* temp_grayscale_v;
+
+    kernel_size = 2 * ((int) (3*sigma)) + 1;
+
+    temp_grayscale_v = (unsigned char*)malloc(ALIGN_TO_FOUR(width) * height);
+    kernel_x = (double *)malloc(kernel_size * kernel_size * sizeof(double));
+    kernel_y = (double *)malloc(kernel_size * kernel_size * sizeof(double));
+
+    getGaussianKernel1D(kernel_x, sigma, kernel_size);
+    getGaussianKernel1D(kernel_y, sigma, kernel_size);
+
+    convolve2Dwith1Dkernel(kernel_x, kernel_size, input_grayscale, width, height, temp_grayscale_v, VERTICAL);
+    convolve2Dwith1Dkernel(kernel_y, kernel_size, temp_grayscale_v, width, height, output_grayscale, HORIZONTAL);
+
+    return 0;
+}
+
 int GaussianBlur2DKernel(unsigned char* inputGrayscale, int width, int height, unsigned char* outputGrayscale, double sigma)
 {
     double* kernel;
@@ -646,6 +786,70 @@ int GaussianBlur2DKernel(unsigned char* inputGrayscale, int width, int height, u
     convolve2D(kernel, kernelSize, inputGrayscale, width, height, outputGrayscale);
 
     free(kernel);
+
+    return 0;
+}
+
+int CannyEdgeDetector(unsigned char* input_grayscale, int width, int height, unsigned char* output_grayscale, double sigma, double threshold, double cutoff_threshold)
+{
+    unsigned int i, j, pitch;
+    unsigned char* input_grayscale_DX;
+    unsigned char* input_grayscale_DXX;
+    unsigned char* input_grayscale_DY;
+    unsigned char* input_grayscale_DYY;
+    unsigned char* input_grayscale_DXY;
+    unsigned char* p_DX;
+    unsigned char* p_DXX;
+    unsigned char* p_DY;
+    unsigned char* p_DYY;
+    unsigned char* p_DXY;
+    unsigned char* p_output;
+    double norm_squared_gradient, magnitude_second_order_directional_derivative, squared_threshold;
+
+    input_grayscale_DX = (unsigned char*)malloc(ALIGN_TO_FOUR(width) * height);
+    input_grayscale_DXX = (unsigned char*)malloc(ALIGN_TO_FOUR(width) * height);
+    input_grayscale_DY = (unsigned char*)malloc(ALIGN_TO_FOUR(width) * height);
+    input_grayscale_DYY = (unsigned char*)malloc(ALIGN_TO_FOUR(width) * height);
+    input_grayscale_DXY = (unsigned char*)malloc(ALIGN_TO_FOUR(width) * height);
+
+    GaussianDerivativeX(input_grayscale, width, height, input_grayscale_DX, sigma);
+    GaussianDerivativeXX(input_grayscale, width, height, input_grayscale_DXX, sigma);
+    GaussianDerivativeY(input_grayscale, width, height, input_grayscale_DY, sigma);
+    GaussianDerivativeYY(input_grayscale, width, height, input_grayscale_DYY, sigma);
+    GaussianDerivativeXY(input_grayscale, width, height, input_grayscale_DXY, sigma);
+
+    squared_threshold = threshold * threshold;
+
+    pitch = ALIGN_TO_FOUR(width);
+
+    for(j=0; j < height; j++) {
+        for(i=0; i < width; i++) {
+            p_DX = input_grayscale_DX + pitch * j + i;
+            p_DXX = input_grayscale_DXX + pitch * j + i;
+            p_DY = input_grayscale_DY + pitch * j + i;
+            p_DYY = input_grayscale_DYY + pitch * j + i;
+            p_DXY = input_grayscale_DXY + pitch * j + i;
+            p_output = output_grayscale + pitch * j + i;
+
+            norm_squared_gradient = (*p_DX) * (*p_DX) + (*p_DY) * (*p_DY);
+
+            *p_output = 0;
+
+            if (norm_squared_gradient >= squared_threshold) {
+                magnitude_second_order_directional_derivative = abs((*p_DX) * (*p_DX) * (*p_DXX) + 2*(*p_DX) * (*p_DY) * (*p_DXY) + (*p_DY) * (*p_DY) * (*p_DYY));
+
+                if ((magnitude_second_order_directional_derivative < 1e-6) && (norm_squared_gradient) >= cutoff_threshold) {
+                    *p_output = norm_squared_gradient;
+                }
+            }
+        }
+    }
+
+    free(input_grayscale_DX);
+    free(input_grayscale_DXX);
+    free(input_grayscale_DY);
+    free(input_grayscale_DYY);
+    free(input_grayscale_DXY);
 
     return 0;
 }

--- a/src/imageprocessing.h
+++ b/src/imageprocessing.h
@@ -56,5 +56,6 @@ void getGaussianKernel1D(double* kernel, double sigma, int kernelSize);
 void getGaussianKernel2D(double* kernel, double sigma, int kernelSize);
 int GaussianBlur2DKernel(unsigned char* inputGrayscale, int width, int height, unsigned char* outputGrayscale, double sigma);
 int GaussianBlur(unsigned char* inputGrayscale, int width, int height, unsigned char* outputGrayscale, double sigma);
+int CannyEdgeDetector(unsigned char* input_grayscale, int width, int height, unsigned char* output_grayscale, double sigma, double threshold, double cutoff_threshold);
 
 #endif


### PR DESCRIPTION
Add a basic Canny Edge Detector that calculates the directional derivative
of the image intensity, then checks the second order directional derivative
of the image intensity in the direction of the directional derivative and
uses that to decide whether a pixel belongs to an edge or not.